### PR TITLE
marketplace-testing: increase timeout

### DIFF
--- a/marketplace-testing.sh
+++ b/marketplace-testing.sh
@@ -164,4 +164,4 @@ spec:
 EOF
 
 echo "Waiting for HCO to get fully deployed"
-oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=10m
+oc wait -n ${TARGET_NAMESPACE} hyperconverged hyperconverged-cluster --for condition=Available --timeout=20m


### PR DESCRIPTION
node-labeller takes more than 10 minutes to go into state running,
therefore i am adding more time to wait (20m)